### PR TITLE
Add legal documents for app publication

### DIFF
--- a/HAFTUNGSERKLAERUNG.md
+++ b/HAFTUNGSERKLAERUNG.md
@@ -1,0 +1,82 @@
+# Haftungserklärung
+
+## Verantwortlichkeit für die Futterbock App
+
+### Präambel
+
+Die nachfolgende Erklärung regelt die Haftung und Verantwortlichkeit für die mobile Anwendung "Futterbock" (nachfolgend "die App"), welche von Jimmy Nelle im Google Play Store und Apple App Store veröffentlicht wird.
+
+### § 1 Verantwortliche Gesellschaft
+
+**Bock Bücher UG (haftungsbeschränkt)**
+Am Rasen 39
+37214 Witzenhausen
+
+vertreten durch:
+- Gesa Kaltenecker
+- Florian Gutnoff
+
+(nachfolgend "Verantwortliche" genannt)
+
+### § 2 Gegenstand der Erklärung
+
+1. Die Verantwortliche erklärt hiermit, dass sie die alleinige inhaltliche und rechtliche Verantwortung für die App "Futterbock" trägt.
+
+2. Die Verantwortliche übernimmt die vollständige Haftung für:
+   - Den Inhalt der App
+   - Die Funktionalität der App
+   - Die Einhaltung geltender Gesetze und Vorschriften
+   - Datenschutzrechtliche Verpflichtungen
+   - Eventuelle Schäden oder Rechtsverletzungen, die durch die Nutzung der App entstehen
+
+### § 3 Freistellung des Publishers
+
+1. Die Verantwortliche stellt das Unternehmen, welches die App im Play Store/App Store veröffentlicht (nachfolgend "Publisher" genannt), von jeglicher Haftung frei.
+
+2. Der Publisher übernimmt ausschließlich die technische Veröffentlichung der App in den App Stores und trägt keine inhaltliche Verantwortung.
+
+3. Die Verantwortliche verpflichtet sich, den Publisher von sämtlichen Ansprüchen Dritter freizustellen, die sich aus der Nutzung, dem Inhalt oder der Funktionalität der App ergeben.
+
+### § 4 Umfang der Haftung
+
+Die Haftung der Verantwortlichen umfasst insbesondere, aber nicht ausschließlich:
+
+- Urheberrechtsverletzungen
+- Datenschutzverletzungen (DSGVO)
+- Wettbewerbsrechtliche Verstöße
+- Produkthaftung
+- Schäden durch fehlerhafte Funktionalität
+- Verletzung von Persönlichkeitsrechten
+- Verstoß gegen gesetzliche Vorschriften
+
+### § 5 Geltungsdauer
+
+Diese Haftungserklärung gilt ab dem Zeitpunkt der Veröffentlichung der App in den App Stores und bleibt für die gesamte Dauer der Verfügbarkeit der App gültig.
+
+### § 6 Salvatorische Klausel
+
+Sollten einzelne Bestimmungen dieser Erklärung unwirksam oder undurchführbar sein oder werden, berührt dies die Wirksamkeit der übrigen Bestimmungen nicht.
+
+---
+
+**Ort, Datum:** _____________________
+
+**Unterschrift Gesa Kaltenecker:**
+
+_____________________
+
+
+**Unterschrift Florian Gutnoff:**
+
+_____________________
+
+
+---
+
+**Zur Kenntnis genommen (Publisher):**
+
+**Name des Publishers:** _____________________
+
+**Unterschrift:** _____________________
+
+**Datum:** _____________________

--- a/IMPRESSUM.md
+++ b/IMPRESSUM.md
@@ -1,0 +1,37 @@
+# Impressum
+
+## Angaben gemäß § 5 TMG
+
+**Bock Bücher UG (haftungsbeschränkt)**
+Am Rasen 39
+37214 Witzenhausen
+
+## Vertreten durch:
+- Gesa Kaltenecker
+- Florian Gutnoff
+
+## Kontakt
+
+**Telefon:** 017678909619
+**E-Mail:** kontakt@bockbuecher.de
+
+## Registereintrag
+
+Eintragung im Handelsregister
+Registergericht: [Registergericht eintragen]
+Registernummer: [Registernummer eintragen]
+
+## Umsatzsteuer-ID
+
+Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz:
+[USt-IdNr. eintragen]
+
+## Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV
+
+Bock Bücher UG (haftungsbeschränkt)
+Am Rasen 39
+37214 Witzenhausen
+
+---
+
+**Stand:** März 2026


### PR DESCRIPTION
Added Impressum and Haftungserklärung (liability declaration) for Bock Bücher UG. The liability declaration states that Bock Bücher UG assumes full responsibility for the Futterbock app while the publisher (Jimmy Nelle) is exempt from liability.