### PR TITLE
feat: rename iOS app to Futterbock + save confirmation snackbar

### DIFF
--- a/composeApp/src/commonMain/kotlin/view/admin/new_participant/ActionsNewParticipant.kt
+++ b/composeApp/src/commonMain/kotlin/view/admin/new_participant/ActionsNewParticipant.kt
@@ -27,4 +27,5 @@ interface ActionsNewParticipant : BaseAction {
     }
 
     data object Save : ActionsNewParticipant
+    data object DismissSuccess : ActionsNewParticipant
 }

--- a/composeApp/src/commonMain/kotlin/view/admin/new_participant/NewParicipant.kt
+++ b/composeApp/src/commonMain/kotlin/view/admin/new_participant/NewParicipant.kt
@@ -32,6 +32,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
@@ -115,6 +118,18 @@ fun NewParicipant(
 ) {
 
     val focusManager = LocalFocusManager.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val successMessage = (state as? ResultState.Success)?.data?.successMessage
+
+    LaunchedEffect(successMessage) {
+        if (successMessage != null) {
+            snackbarHostState.showSnackbar(
+                message = successMessage,
+                duration = SnackbarDuration.Short
+            )
+            onAction(ActionsNewParticipant.DismissSuccess)
+        }
+    }
 
     AppTheme {
         Scaffold(
@@ -123,6 +138,7 @@ fun NewParicipant(
                 .pointerInput(Unit) {
                     detectTapGestures(onTap = { focusManager.clearFocus() })
                 },
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             topBar = {
                 TopAppBar(title = {
                     Text(text = "Teilnehmende hinzufügen")

--- a/composeApp/src/commonMain/kotlin/view/admin/new_participant/ViewModelNewParticipant.kt
+++ b/composeApp/src/commonMain/kotlin/view/admin/new_participant/ViewModelNewParticipant.kt
@@ -25,6 +25,7 @@ data class NewParticipantState(
     val isNewParticipant: Boolean = true,
     val allergies: List<String> = emptyList(),
     val selectedGroup: String = "",
+    val successMessage: String? = null,
 )
 
 class ViewModelNewParticipant(
@@ -57,6 +58,7 @@ class ViewModelNewParticipant(
             )
 
             is ActionsNewParticipant.DeleteParticipant -> deleteParticipant(actionsNewParticipant.participantId)
+            is ActionsNewParticipant.DismissSuccess -> dismissSuccess()
         }
     }
 
@@ -112,10 +114,12 @@ class ViewModelNewParticipant(
             allergies = data.allergies
             selectedGroup = data.selectedGroup
         }
+        val name = "${data.firstName} ${data.lastName}"
+        val isNew = data.isNewParticipant
         viewModelScope.launch {
             try {
-                if (data.isNewParticipant) {
-                    Logger.i("Create new Participant with name ${participant.firstName} ${participant.lastName}")
+                if (isNew) {
+                    Logger.i("Create new Participant with name $name")
                     val success = eventRepository.createNewParticipant(participant)
                     if (success == null) {
                         _state.value =
@@ -123,15 +127,24 @@ class ViewModelNewParticipant(
                         return@launch
                     }
                 } else {
-                    Logger.i("Update Participant with name ${participant.firstName} ${participant.lastName}")
+                    Logger.i("Update Participant with name $name")
                     eventRepository.updateParticipant(participant)
                 }
             } catch (e: Exception) {
                 Logger.e("" + e.message)
-                ResultState.Error("Fehler beim anlegen des Teilnehmenden")
+                _state.value = ResultState.Error("Fehler beim Anlegen des Teilnehmenden")
+                return@launch
             }
             initializeScreenWithNewParticipant()
+            val currentData = state.value.getSuccessData() ?: return@launch
+            val message = if (isNew) "$name wurde erstellt" else "$name wurde aktualisiert"
+            _state.value = ResultState.Success(currentData.copy(successMessage = message))
         }
+    }
+
+    private fun dismissSuccess() {
+        val data = state.value.getSuccessData() ?: return
+        _state.value = ResultState.Success(data.copy(successMessage = null))
     }
 
     private fun initializeWithParticipant(participant: Participant) {

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,3 @@
 TEAM_ID=
 BUNDLE_ID=org.futterbock.app.FutterbockApp
-APP_NAME=Futterbock_App
+APP_NAME=Futterbock

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
-		7555FF7B242A565900829871 /* Futterbock_App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Futterbock_App.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7555FF7B242A565900829871 /* Futterbock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Futterbock.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A2B2A19F2CB27F14005F4BA8 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -85,7 +85,7 @@
 		7555FF7C242A565900829871 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7555FF7B242A565900829871 /* Futterbock_App.app */,
+				7555FF7B242A565900829871 /* Futterbock.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -134,7 +134,7 @@
 				A2D424BC2CEA1D250051BAF0 /* FirebaseFirestore */,
 			);
 			productName = iosApp;
-			productReference = 7555FF7B242A565900829871 /* Futterbock_App.app */;
+			productReference = 7555FF7B242A565900829871 /* Futterbock.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */


### PR DESCRIPTION
## Summary
- Rename iOS app display name from `Futterbock_App` to `Futterbock` (Config.xcconfig + project.pbxproj)
- Add Snackbar success message after creating/updating participants (e.g. "Max Mustermann wurde erstellt")

## Test plan
- [ ] iOS: Clean build, verify app name shows as "Futterbock"
- [ ] Teilnehmende hinzufuegen: nach Speichern erscheint Snackbar mit Name
- [ ] Teilnehmende bearbeiten: nach Speichern erscheint "wurde aktualisiert"