### PR TITLE
fix: Race-Condition behebt Rezept-Verlust bei Mahlzeiten

### DIFF
--- a/composeApp/src/commonMain/kotlin/view/event/SharedEventViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/view/event/SharedEventViewModel.kt
@@ -88,19 +88,6 @@ class SharedEventViewModel(
         }
     }
 
-    suspend fun saveMealAndAwait() {
-        actionMutex.withLock {
-            val currentState = eventState.value.getSuccessData() ?: return
-            _eventState.value = handleEditMeal.handleAction(currentState, EditMealActions.SaveMeal)
-        }
-    }
-
-    suspend fun updateAllMealsAndAwait() {
-        actionMutex.withLock {
-            val currentState = eventState.value.getSuccessData() ?: return
-            _eventState.value = handleEditParticipant.handleAction(currentState, EditParticipantActions.UpdateAllMeals)
-        }
-    }
 
 
     fun initializeScreen(eventIdPrm: String?) {

--- a/composeApp/src/commonMain/kotlin/view/event/SharedEventViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/view/event/SharedEventViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
 import kotlinx.datetime.LocalDate
 import model.Event
@@ -66,50 +68,37 @@ class SharedEventViewModel(
         HandleCookingGroupActions(
             eventRepository = eventRepository
         )
-
+    private val actionMutex = Mutex()
 
     fun onAction(editEventActions: BaseAction) {
-        when (editEventActions) {
-            is EditMealActions -> handleEditMealActions(editEventActions)
-            is EditEventActions -> handleEventActions(editEventActions)
-            is EditParticipantActions -> handleEditParticipantActions(editEventActions)
-            is CookingGroupActions -> handleCookingGroupActions(editEventActions)
+        viewModelScope.launch(Dispatchers.IO) {
+            actionMutex.withLock {
+                val currentState = eventState.value.getSuccessData() ?: return@launch
+                if (editEventActions is LoadingAction)
+                    _eventState.value = ResultState.Loading
+
+                _eventState.value = when (editEventActions) {
+                    is EditMealActions -> handleEditMeal.handleAction(currentState, editEventActions)
+                    is EditEventActions -> handleEditEvent.handleAction(currentState, editEventActions)
+                    is EditParticipantActions -> handleEditParticipant.handleAction(currentState, editEventActions)
+                    is CookingGroupActions -> handleCookingGroups.handleAction(currentState, editEventActions)
+                    else -> return@launch
+                }
+            }
         }
     }
 
-    private fun handleEventActions(editEventActions: EditEventActions) {
-        val currentState = eventState.value.getSuccessData() ?: return
-        viewModelScope.launch(Dispatchers.IO) {
-            if (editEventActions is LoadingAction)
-                _eventState.value =
-                    ResultState.Loading
-
-            _eventState.value =
-                handleEditEvent.handleAction(currentState, editEventActions)
+    suspend fun saveMealAndAwait() {
+        actionMutex.withLock {
+            val currentState = eventState.value.getSuccessData() ?: return
+            _eventState.value = handleEditMeal.handleAction(currentState, EditMealActions.SaveMeal)
         }
     }
 
-    private fun handleEditMealActions(editEventActions: EditMealActions) {
-        val currentState = eventState.value.getSuccessData() ?: return
-        viewModelScope.launch(Dispatchers.IO) {
-            _eventState.value =
-                handleEditMeal.handleAction(currentState, editEventActions)
-        }
-    }
-
-    private fun handleEditParticipantActions(editEventActions: EditParticipantActions) {
-        val currentState = eventState.value.getSuccessData() ?: return
-        viewModelScope.launch(Dispatchers.IO) {
-            _eventState.value =
-                handleEditParticipant.handleAction(currentState, editEventActions)
-        }
-    }
-
-    private fun handleCookingGroupActions(action: CookingGroupActions) {
-        val currentState = eventState.value.getSuccessData() ?: return
-        viewModelScope.launch(Dispatchers.IO) {
-            _eventState.value =
-                handleCookingGroups.handleAction(currentState, action)
+    suspend fun updateAllMealsAndAwait() {
+        actionMutex.withLock {
+            val currentState = eventState.value.getSuccessData() ?: return
+            _eventState.value = handleEditParticipant.handleAction(currentState, EditParticipantActions.UpdateAllMeals)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/view/event/new_meal_screen/NewMealPage.kt
+++ b/composeApp/src/commonMain/kotlin/view/event/new_meal_screen/NewMealPage.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,7 +64,6 @@ import model.RecipeSelection
 import model.RecipeType
 import model.Season
 import model.TimeRange
-import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import services.event.ParticipantCanEatRecipe
 import view.event.EventState
@@ -95,7 +93,6 @@ fun EditMealScreen(
     val canParticipantEat: ParticipantCanEatRecipe = koinInject()
     val ingredientViewModel: view.event.categorized_shopping_list.IngredientViewModel = koinInject()
     val ingredientsState = ingredientViewModel.state.collectAsState()
-    val coroutineScope = rememberCoroutineScope()
 
     NewMealPage(
         state = state.value,
@@ -115,12 +112,6 @@ fun EditMealScreen(
 
                 is NavigationActions -> handleNavigation(navController, action)
                 else -> sharedEventViewModel.onAction(action)
-            }
-        },
-        onNavigateBack = {
-            coroutineScope.launch {
-                sharedEventViewModel.saveMealAndAwait()
-                navController.navigateUp()
             }
         },
         participantCanEatRecipe = { participant: ParticipantTime, recipeSelection: RecipeSelection ->
@@ -144,7 +135,6 @@ fun NewMealPage(
     allRecipes: List<Recipe>,
     allIngredients: List<model.Ingredient>,
     onAction: (BaseAction) -> Unit,
-    onNavigateBack: () -> Unit,
     participantCanEatRecipe: (ParticipantTime, RecipeSelection) -> Boolean,
     getRecipeEatingError: suspend (ParticipantTime, RecipeSelection) -> String?,
 ) {
@@ -157,7 +147,6 @@ fun NewMealPage(
         topBar = {
             SearchBarComponent(
                 onAction = onAction,
-                onNavigateBack = onNavigateBack,
                 state = state,
                 allRecipes = allRecipes,
                 allIngredients = allIngredients,
@@ -279,7 +268,6 @@ fun SearchBarComponent(
     allRecipes: List<Recipe>,
     allIngredients: List<model.Ingredient>,
     onAction: (BaseAction) -> Unit,
-    onNavigateBack: () -> Unit,
     isSearchBarActive: Boolean,
     onSearchBarActiveChange: (Boolean) -> Unit
 ) {
@@ -305,7 +293,10 @@ fun SearchBarComponent(
                         onSearch = { onSearchBarActiveChange(false) },
                         isActive = isSearchBarActive,
                         onActiveChange = onSearchBarActiveChange,
-                        onNavigateBack = onNavigateBack
+                        onNavigateBack = {
+                            onAction(EditMealActions.SaveMeal)
+                            onAction(NavigationActions.GoBack)
+                        }
                     )
                 },
                 expanded = isSearchBarActive,

--- a/composeApp/src/commonMain/kotlin/view/event/new_meal_screen/NewMealPage.kt
+++ b/composeApp/src/commonMain/kotlin/view/event/new_meal_screen/NewMealPage.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,6 +65,7 @@ import model.RecipeSelection
 import model.RecipeType
 import model.Season
 import model.TimeRange
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import services.event.ParticipantCanEatRecipe
 import view.event.EventState
@@ -93,6 +95,7 @@ fun EditMealScreen(
     val canParticipantEat: ParticipantCanEatRecipe = koinInject()
     val ingredientViewModel: view.event.categorized_shopping_list.IngredientViewModel = koinInject()
     val ingredientsState = ingredientViewModel.state.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
 
     NewMealPage(
         state = state.value,
@@ -112,6 +115,12 @@ fun EditMealScreen(
 
                 is NavigationActions -> handleNavigation(navController, action)
                 else -> sharedEventViewModel.onAction(action)
+            }
+        },
+        onNavigateBack = {
+            coroutineScope.launch {
+                sharedEventViewModel.saveMealAndAwait()
+                navController.navigateUp()
             }
         },
         participantCanEatRecipe = { participant: ParticipantTime, recipeSelection: RecipeSelection ->
@@ -135,6 +144,7 @@ fun NewMealPage(
     allRecipes: List<Recipe>,
     allIngredients: List<model.Ingredient>,
     onAction: (BaseAction) -> Unit,
+    onNavigateBack: () -> Unit,
     participantCanEatRecipe: (ParticipantTime, RecipeSelection) -> Boolean,
     getRecipeEatingError: suspend (ParticipantTime, RecipeSelection) -> String?,
 ) {
@@ -147,6 +157,7 @@ fun NewMealPage(
         topBar = {
             SearchBarComponent(
                 onAction = onAction,
+                onNavigateBack = onNavigateBack,
                 state = state,
                 allRecipes = allRecipes,
                 allIngredients = allIngredients,
@@ -268,6 +279,7 @@ fun SearchBarComponent(
     allRecipes: List<Recipe>,
     allIngredients: List<model.Ingredient>,
     onAction: (BaseAction) -> Unit,
+    onNavigateBack: () -> Unit,
     isSearchBarActive: Boolean,
     onSearchBarActiveChange: (Boolean) -> Unit
 ) {
@@ -293,11 +305,7 @@ fun SearchBarComponent(
                         onSearch = { onSearchBarActiveChange(false) },
                         isActive = isSearchBarActive,
                         onActiveChange = onSearchBarActiveChange,
-                        onNavigateBack = {
-                            onAction(EditMealActions.SaveMeal)
-                            onAction(NavigationActions.GoBack)
-
-                        }
+                        onNavigateBack = onNavigateBack
                     )
                 },
                 expanded = isSearchBarActive,

--- a/composeApp/src/commonMain/kotlin/view/event/participants/ParticipantPage.kt
+++ b/composeApp/src/commonMain/kotlin/view/event/participants/ParticipantPage.kt
@@ -23,14 +23,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import model.ParticipantTime
-import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import view.event.EventState
 import view.event.SharedEventViewModel
@@ -52,7 +50,6 @@ fun ParticipantScreen(
 ) {
     val sharedEventViewModel: SharedEventViewModel = koinInject()
     val state = sharedEventViewModel.eventState.collectAsStateWithLifecycle()
-    val coroutineScope = rememberCoroutineScope()
 
     ParticipantPage(
         state = state.value,
@@ -60,12 +57,6 @@ fun ParticipantScreen(
             when (action) {
                 is NavigationActions -> handleNavigation(navController, action)
                 else -> sharedEventViewModel.onAction(action)
-            }
-        },
-        onNavigateBack = {
-            coroutineScope.launch {
-                sharedEventViewModel.updateAllMealsAndAwait()
-                navController.navigateUp()
             }
         }
     )
@@ -76,8 +67,7 @@ fun ParticipantScreen(
 @Composable
 fun ParticipantPage(
     state: ResultState<EventState>,
-    onAction: (BaseAction) -> Unit,
-    onNavigateBack: () -> Unit
+    onAction: (BaseAction) -> Unit
 ) {
 
     var showDatePicker by remember { mutableStateOf(false) }
@@ -89,7 +79,10 @@ fun ParticipantPage(
                 title = { Text("Teilnehmendenliste") },
                 navigationIcon = {
                     NavigationIconButton(
-                        onLeave = onNavigateBack
+                        onLeave = {
+                            onAction(EditParticipantActions.UpdateAllMeals)
+                            onAction(NavigationActions.GoBack)
+                        }
                     )
                 }
             )

--- a/composeApp/src/commonMain/kotlin/view/event/participants/ParticipantPage.kt
+++ b/composeApp/src/commonMain/kotlin/view/event/participants/ParticipantPage.kt
@@ -23,12 +23,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import model.ParticipantTime
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import view.event.EventState
 import view.event.SharedEventViewModel
@@ -50,6 +52,7 @@ fun ParticipantScreen(
 ) {
     val sharedEventViewModel: SharedEventViewModel = koinInject()
     val state = sharedEventViewModel.eventState.collectAsStateWithLifecycle()
+    val coroutineScope = rememberCoroutineScope()
 
     ParticipantPage(
         state = state.value,
@@ -57,6 +60,12 @@ fun ParticipantScreen(
             when (action) {
                 is NavigationActions -> handleNavigation(navController, action)
                 else -> sharedEventViewModel.onAction(action)
+            }
+        },
+        onNavigateBack = {
+            coroutineScope.launch {
+                sharedEventViewModel.updateAllMealsAndAwait()
+                navController.navigateUp()
             }
         }
     )
@@ -67,7 +76,8 @@ fun ParticipantScreen(
 @Composable
 fun ParticipantPage(
     state: ResultState<EventState>,
-    onAction: (BaseAction) -> Unit
+    onAction: (BaseAction) -> Unit,
+    onNavigateBack: () -> Unit
 ) {
 
     var showDatePicker by remember { mutableStateOf(false) }
@@ -79,10 +89,7 @@ fun ParticipantPage(
                 title = { Text("Teilnehmendenliste") },
                 navigationIcon = {
                     NavigationIconButton(
-                        onLeave = {
-                            onAction(NavigationActions.GoBack)
-                            onAction(EditParticipantActions.UpdateAllMeals)
-                        }
+                        onLeave = onNavigateBack
                     )
                 }
             )


### PR DESCRIPTION
## Summary
- **Mutex in `SharedEventViewModel.onAction()`**: Alle State-Mutationen werden jetzt serialisiert. Der State wird erst innerhalb des Locks gelesen, sodass parallele Aktionen sich nicht mehr gegenseitig überschreiben.
- **SaveMeal wird vor Navigation abgewartet** (`NewMealPage`): Statt fire-and-forget wird `saveMealAndAwait()` aufgerufen und erst nach erfolgreichem Firebase-Write navigiert.
- **UpdateAllMeals wird vor Navigation abgewartet** (`ParticipantPage`): Reihenfolge korrigiert (vorher: GoBack → UpdateAllMeals, jetzt: UpdateAllMeals → GoBack) und Save wird abgewartet.

## Ursache
Aktionen im `SharedEventViewModel` starteten unabhängige Coroutines, die jeweils den State vor dem `launch` lasen. Bei schneller Navigation oder schlechtem Internet überschrieb die zweite Aktion das Ergebnis der ersten — Rezeptdaten gingen verloren.

## Test plan
- [ ] Rezepte zu mehreren Mahlzeiten hinzufügen, schnell zwischen Mahlzeiten navigieren, App neustarten → Rezepte prüfen
- [ ] Teilnehmerseite öffnen, Teilnehmer hinzufügen, zurück navigieren → Mahlzeiten-Rezepte prüfen
- [ ] Im Emulator mit "Poor" Network-Typ testen
- [ ] Bestehende Tests laufen (`./gradlew :composeApp:testDebugUnitTest`)